### PR TITLE
Added bowtie2 module options for sorted, indexed bam and to output unmapped reads

### DIFF
--- a/configs/module-defaults.config
+++ b/configs/module-defaults.config
@@ -132,6 +132,8 @@ params {
             suffix           = ""
             publish_dir      = "bowtie2"
             publish_results  = "all"
+            unmapped_suffix  = ""
+            output_sam       = false
         }
         'bowtie2_build' {
             args             = ""

--- a/tools/bowtie2/environment.yml
+++ b/tools/bowtie2/environment.yml
@@ -7,3 +7,5 @@ channels:
   - defaults
 dependencies:
   - bowtie2=2.4.1
+  - samtools=1.9
+  - pigz=2.3.4

--- a/tools/bowtie2/main.nf
+++ b/tools/bowtie2/main.nf
@@ -20,7 +20,10 @@ process bowtie2_align {
         path index
 
     output:
-        tuple val(meta), path("*.sam"), emit: sam
+        tuple val(meta), path("*.sam"), optional: true, emit: sam
+        tuple val(meta), path("*.bam"), path("*.bai"), optional: true, emit: bam
+        tuple val(meta), path("${prefix}${opts.suffix}.1.fastq.gz"), path("${prefix}${opts.suffix}.2.fastq.gz"), optional: true, emit: unmappedFastqPaired
+        tuple val(meta), path("${prefix}${opts.suffix}.fastq.gz"), optional: true, emit: unmappedFastqSingle
         path "*stats.txt", emit: report
 
     script:
@@ -40,9 +43,30 @@ process bowtie2_align {
             files = '-U ' + reads[0]
         }
 
+        // If clause for creating unmapped filename if requested
+        if(opts.unmapped_suffix && opts.unmapped_suffix != '') {
+            if(readList.size > 1){
+                args += ' --un-conc ' + "${meta.sample_id}${opts.unmapped_suffix}" + '.fastq.gz'
+            }
+            else {
+                args += ' --un ' + "${meta.sample_id}${opts.unmapped_suffix}" + '.fastq.gz'
+            }
+        }
+
         prefix = opts.suffix ? "${meta.sample_id}${opts.suffix}" : "${meta.sample_id}"
 
-        command = "bowtie2 -x ${index[0].simpleName} $args $files 2>bowtie2_stats.txt > ${prefix}.sam"
+        // command = "bowtie2 -x ${index[0].simpleName} $args $files 2>bowtie2_stats.txt > ${prefix}.sam"
+
+        sort_command = "samtools sort -@ ${task.cpus} /dev/stdin > ${prefix}.bam"
+        index_command = "samtools index -@ ${task.cpus} ${prefix}.bam"
+
+        if ( opts.output_sam && opts.output_sam == true ) {
+            command = "bowtie2 -x ${index[0].simpleName} $args $files 2>bowtie2_stats.txt > ${prefix}.sam"
+        }
+        else {
+            command = "bowtie2 -x ${index[0].simpleName} $args $files 2>bowtie2_stats.txt | $sort_command && $index_command"
+        }
+
         if (params.verbose){
             println ("[MODULE] bowtie2 command: " + command)
         }

--- a/tools/bowtie2/test/main.nf
+++ b/tools/bowtie2/test/main.nf
@@ -50,10 +50,10 @@ workflow {
     // bowtie2_align.out.sam | view
 
     //Check count
-    // assert_channel_count( bowtie2_align.out.sam, "sam", 2)
+    assert_channel_count( bowtie2_align.out.sam, "sam", 0)
     assert_channel_count( bowtie2_align.out.bam, "bam", 3)
-    assert_channel_count( bowtie2_align.out.unmappedFastqPaired, "unmappedFastqPaired", 3)
-    // assert_channel_count( bowtie2_align.out.unmappedFastqSingle, "unmappedFastqSingle", 2)
+    assert_channel_count( bowtie2_align.out.unmappedFastqPaired, "unmappedFastqPaired", 0)
+    assert_channel_count( bowtie2_align.out.unmappedFastqSingle, "unmappedFastqSingle", 0)
 }
 
     //ch_fastq_paired_end.merge(bowtie2_build.out.bowtieIndex.map{x -> [x]})

--- a/tools/bowtie2/test/main.nf
+++ b/tools/bowtie2/test/main.nf
@@ -45,12 +45,15 @@ Channel
 workflow {
     bowtie2_build( params.modules['bowtie2_build'], ch_fasta )
 
-    bowtie2_align ( params.modules['bowtie2_align'], ch_fastq_paired_end, bowtie2_build.out.bowtieIndex.collect() )
+    bowtie2_align( params.modules['bowtie2_align'], ch_fastq_paired_end, bowtie2_build.out.bowtieIndex.collect() )
 
-    bowtie2_align.out.sam | view
+    // bowtie2_align.out.sam | view
 
     //Check count
-    assert_channel_count( bowtie2_align.out.sam, "sam", 2)
+    // assert_channel_count( bowtie2_align.out.sam, "sam", 2)
+    assert_channel_count( bowtie2_align.out.bam, "bam", 3)
+    assert_channel_count( bowtie2_align.out.unmappedFastqPaired, "unmappedFastqPaired", 3)
+    // assert_channel_count( bowtie2_align.out.unmappedFastqSingle, "unmappedFastqSingle", 2)
 }
 
     //ch_fastq_paired_end.merge(bowtie2_build.out.bowtieIndex.map{x -> [x]})

--- a/tools/bowtie2/test/main.nf
+++ b/tools/bowtie2/test/main.nf
@@ -51,7 +51,7 @@ workflow {
 
     //Check count
     assert_channel_count( bowtie2_align.out.sam, "sam", 0)
-    assert_channel_count( bowtie2_align.out.bam, "bam", 3)
+    assert_channel_count( bowtie2_align.out.bam, "bam", 2)
     assert_channel_count( bowtie2_align.out.unmappedFastqPaired, "unmappedFastqPaired", 0)
     assert_channel_count( bowtie2_align.out.unmappedFastqSingle, "unmappedFastqSingle", 0)
 }

--- a/tools/bowtie2/test/main.nf
+++ b/tools/bowtie2/test/main.nf
@@ -47,7 +47,7 @@ workflow {
 
     bowtie2_align( params.modules['bowtie2_align'], ch_fastq_paired_end, bowtie2_build.out.bowtieIndex.collect() )
 
-    // bowtie2_align.out.sam | view
+    bowtie2_align.out.bam | view
 
     //Check count
     assert_channel_count( bowtie2_align.out.sam, "sam", 0)


### PR DESCRIPTION
Two main updates as above with the following changes:

1. Added an `output_sam` Boolean arg (default false) to control flow into sam or bam command routes
2. If bam output, then Bowtie2 output is piped to `samtools sort` and `samtools index` run if sorting succeeds
3. Added optional `unmapped_suffix` arg and ifelse statement to select unmapped parameter correctly and generate unmapped fastq filenames in a pair or unpaired aware manner
4. Changed output channels to optional (as per Slava's STAR module) as not all will exist
5. Added samtools and pigz to `environment.yaml` for Docker container
