### PR TITLE
revamp to use minionqc conda environment; simplify test data set

### DIFF
--- a/tools/minionqc/Dockerfile
+++ b/tools/minionqc/Dockerfile
@@ -5,20 +5,10 @@ LABEL authors="michael.mansfield@oist.jp" \
 
 # Install all of R's dependencies, then install R
 RUN apt-get update \
-  && apt-get install -y libblas-dev libcurl4-openssl-dev libicu-dev liblapack-dev libpcre2-dev libxml2-dev libssl-dev wget curl python3-pip ruby ruby-dev \
-  && apt-get install -y r-base \
-	&& apt-get install -y r-cran-ggplot2
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
-# Install R packages
-RUN R -e "install.packages('data.table', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('futile.logger', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('optparse', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('plyr', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('readr', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('reshape2', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('scales', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('viridis', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-RUN R -e "install.packages('yaml', dependencies=TRUE, repos='https://cloud.r-project.org/')"
-
-# Get the actual minionQC code
-RUN curl https://raw.githubusercontent.com/roblanf/minion_qc/master/MinIONQC.R > /MinIONQC.R && chmod +x /MinIONQC.R
+# Install conda packages
+COPY environment.yml /
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH /opt/conda/envs/nfcore-module-minionqc/bin:$PATH

--- a/tools/minionqc/environment.yml
+++ b/tools/minionqc/environment.yml
@@ -1,0 +1,8 @@
+# This file creates a conda environment for the minionQC module
+#   conda env create -f environment.yml
+name: nfcore-module-minionqc
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - r-minionqc=1.4.2

--- a/tools/minionqc/main.nf
+++ b/tools/minionqc/main.nf
@@ -12,14 +12,14 @@ process minionqc {
                       if (opts.publish_results == "none") null
                       else filename }
 
-    container "luslab/nf-modules-minionqc:latest"
+    container "luslab/nf-modules-minionqc:conda-minionqc"
 
     input:
         val opts
         tuple val(meta), path(sequencing_summary)
 
     output:
-        tuple val(meta), path("minionqc"), emit: minionqcOutputs
+        tuple val(meta), path("minionqc"), emit: minionqc_output_dir
 
     script:
 
@@ -29,7 +29,7 @@ process minionqc {
         args += ext_args.trim()
     }
 
-    minionqc_command = "Rscript /MinIONQC.R -p ${task.cpus} ${args} -o minionqc -i $sequencing_summary"
+    minionqc_command = "MinIONQC.R -p ${task.cpus} ${args} -o minionqc -i $sequencing_summary"
 
     if (params.verbose){
         println ("[MODULE] minionqc command: " + minionqc_command)

--- a/tools/minionqc/test/input/sequencing_summary.txt
+++ b/tools/minionqc/test/input/sequencing_summary.txt
@@ -1,1 +1,0 @@
-../../../../test_data/guppy_sequencing_summary/sequencing_summary.txt

--- a/tools/minionqc/test/main.nf
+++ b/tools/minionqc/test/main.nf
@@ -17,21 +17,21 @@ params.verbose = true
 --------------------------------------------------------------------------------------*/
 
 include {minionqc} from "../main.nf"
-include {assert_channel_count} from '../../../workflows/test_flows/main.nf'
+include {assert_channel_count} from "../../../workflows/test_flows/main.nf"
 
 /*------------------------------------------------------------------------------------*/
 /* Define input channels
 --------------------------------------------------------------------------------------*/
 
-testDataGuppyOut= [
-    [[sample_id:"test-sample"], "$baseDir/../../../test_data/guppy_sequencing_summary/sequencing_summary.txt"],
+test_data_sequencing_summary = [
+    [[sample_id:"test-sample"], "$baseDir/../../../test_data/lamda1000a/lambda_top10.sequence_summary.txt"],
 ]
 
 //Define test data input channels
 Channel
-    .from(testDataGuppyOut)
+    .from(test_data_sequencing_summary)
     .map { row -> [ row[0], file(row[1], checkIfExists: true) ] }
-    .set {ch_guppyout_data}
+    .set {ch_sequencing_summary}
 
 /*------------------------------------------------------------------------------------*/
 /* Run tests
@@ -39,10 +39,10 @@ Channel
 
 workflow {
     // Run minionqc on the test set
-    minionqc(params.modules['minionqc'], ch_guppyout_data)
+    minionqc(params.modules['minionqc'], ch_sequencing_summary)
 
     // Collect file names and view output
-    minionqc.out.minionqcOutputs | view
+    minionqc.out.minionqc_output_dir | view
 
-    assert_channel_count( minionqc.out.minionqcOutputs, "reads", 1)
+    assert_channel_count( minionqc.out.minionqc_output_dir, "reads", 1)
 }

--- a/tools/minionqc/test/main.nf
+++ b/tools/minionqc/test/main.nf
@@ -27,7 +27,6 @@ test_data_sequencing_summary = [
     [[sample_id:"test-sample"], "$baseDir/../../../test_data/lamda1000a/lambda_top10.sequence_summary.txt"],
 ]
 
-//Define test data input channels
 Channel
     .from(test_data_sequencing_summary)
     .map { row -> [ row[0], file(row[1], checkIfExists: true) ] }


### PR DESCRIPTION
Revamped the `minionqc` module to use conda installation instead of building R and dependent libraries from scratch. There is a biocontainer for `minionqc`, but it has issues (e.g. R version 3.2.2) so we will have to maintain our own image for now (pushed with a new corresponding tag `conda-minionqc`).

I also touched up some details e.g. removed camel case where it appeared.